### PR TITLE
fix import to match usage of NumCore

### DIFF
--- a/load.go
+++ b/load.go
@@ -1,7 +1,7 @@
 package goshin
 
 import "fmt"
-import linuxproc "github.com/c9s/goprocinfo/linux"
+import linuxproc "github.com/pariviere/goprocinfo/linux"
 
 type LoadAverage struct {
 	last1m, last5m, last15m float64


### PR DESCRIPTION
The c9s version of goprocinfo uses NumCPU() instead of NumCore()