### PR TITLE
Fix self import package name.

### DIFF
--- a/launcher/goshin.go
+++ b/launcher/goshin.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/pariviere/goshin"
+import "github.com/ippontech/goshin"
 import "flag"
 import "fmt"
 import "os"


### PR DESCRIPTION
There was an import that referenced `github.com/pariviere/goshin`
That repo does not exist and would cause the build to fail.
Now it points to github.com/ippontech/goshin

